### PR TITLE
Fix PCRE version of [:^S:]&[:^Z:]

### DIFF
--- a/bin/punic-build-data
+++ b/bin/punic-build-data
@@ -2524,7 +2524,7 @@ class NumbersLocalePunicConversion extends LocalePunicConversion
                 $regexp = '[^\pS]';
                 break;
             case '[[:^S:]&[:^Z:]]':
-                $regexp = '[[^\pS]&[\S]]';
+                $regexp = '[^\pS\pZ]';
                 break;
             default:
                 throw new Exception("Unsupported match: $match");


### PR DESCRIPTION
CLDR 38 introduced a new pattern, `[[:^S:]&[:^Z:]]`.

Amperand means intersection (see [here](https://github.com/unicode-org/cldr/blob/release-39/docs/ldml/tr35.md#Boolean_Operations)), so `[[:^S:]&[:^Z:]]` will match any character that is neither a symbol (S) nor a separator (Z). The PCRE equivalent of this is `[^\pS\pZ]`.

AFAIK ampersand has no special meaning in PCRE expressions, so I don't think `[[^\pS]&[\S]]` works as intended.