### PR TITLE
England/Scotland/Wales subdivisions not translated for CLDR 39

### DIFF
--- a/src/Build/Converter.php
+++ b/src/Build/Converter.php
@@ -199,7 +199,7 @@ abstract class Converter
     protected function toPhpSprintf($fmt)
     {
         if (!is_string($fmt)) {
-            throw new RuntimeException('Wrong parameter type for ' . get_class($this) . '::' . __METHOD__);
+            throw new RuntimeException('Wrong parameter type for ' . static::class . '::' . __METHOD__);
         }
 
         return preg_replace_callback(

--- a/src/Build/Converter/Locale/Subdivisions.php
+++ b/src/Build/Converter/Locale/Subdivisions.php
@@ -63,9 +63,9 @@ class Subdivisions extends Locale
         }
         $localeDisplayNames = require $localeDisplayNamesFile;
 
-        $data[$this->type][$key]['localeDisplayNames']['subdivisions']['subdivision'] =
-            ($localeDisplayNames['subdivisions'] ?? []) +
-            $data[$this->type][$key]['localeDisplayNames']['subdivisions']['subdivision'];
+        $data[$this->type][$key]['localeDisplayNames']['subdivisions']['subdivision']
+            = ($localeDisplayNames['subdivisions'] ?? [])
+            + $data[$this->type][$key]['localeDisplayNames']['subdivisions']['subdivision'];
 
         uksort($data[$this->type][$key]['localeDisplayNames']['subdivisions']['subdivision'], 'strcasecmp');
 

--- a/src/DataSymlinker.php
+++ b/src/DataSymlinker.php
@@ -185,7 +185,6 @@ class DataSymlinker
                     $this->symlinks[$link] = $target;
                     $progress->advance();
                 }
-                
             }
             $progress->finish();
         }


### PR DESCRIPTION
England, Scotland, Wales are not translated in the Punic data based on CLDR 39.

The implementation added in #10 assumes that these subdivisions are not present in the `subdivisions/*.xml` files. But in https://github.com/unicode-org/cldr/pull/375 they were added to `subdivisions/en.xml` (only for the `en` locale), so the English strings overwrite the locale-specific strings from `localeDisplayNames`.